### PR TITLE
changed data type of return and pickup dates from datetime to date in…

### DIFF
--- a/db/migrate/20220518152647_change_pick_up_date_type_to_date_in_bookings.rb
+++ b/db/migrate/20220518152647_change_pick_up_date_type_to_date_in_bookings.rb
@@ -1,0 +1,5 @@
+class ChangePickUpDateTypeToDateInBookings < ActiveRecord::Migration[6.1]
+  def change
+    change_column :bookings, :pick_up_date, :date
+  end
+end

--- a/db/migrate/20220518152702_change_return_date_type_to_date_in_bookings.rb
+++ b/db/migrate/20220518152702_change_return_date_type_to_date_in_bookings.rb
@@ -1,0 +1,5 @@
+class ChangeReturnDateTypeToDateInBookings < ActiveRecord::Migration[6.1]
+  def change
+    change_column :bookings, :return_date, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_16_200806) do
+ActiveRecord::Schema.define(version: 2022_05_18_152702) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -46,8 +46,8 @@ ActiveRecord::Schema.define(version: 2022_05_16_200806) do
   create_table "bookings", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "record_id", null: false
-    t.datetime "pick_up_date"
-    t.datetime "return_date"
+    t.date "pick_up_date"
+    t.date "return_date"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["record_id"], name: "index_bookings_on_record_id"


### PR DESCRIPTION
… bookings table

Do we need these columns to be formatted to datetime rather than date in order for strftime methods to work in the index and show pages? Can't find a definitive answer online but I am getting errors in the index and show pages now.